### PR TITLE
feat(segmentation): accommodates heading text length in segmentation

### DIFF
--- a/scripts/segment_legal_code.py
+++ b/scripts/segment_legal_code.py
@@ -8,6 +8,7 @@ Usage:
 
 import sys
 from pathlib import Path
+import polars as pl
 
 # Load environment variables from .env file
 try:
@@ -87,13 +88,21 @@ def segment_legal_code(jurisdiction_path: str) -> None:
         sections_df = divide_into_sections(content)
         sections_df = add_parent_relationships(sections_df)
 
+        # Add total word count for heading_text + body_text
+        sections_df = sections_df.with_columns(
+            (pl.col("heading_text") + " " + pl.col("body_text"))
+            .str.split(" ")
+            .list.len()
+            .alias("section_word_count")
+        )
+
         print("Creating segments...")
         # Create segments
         segments_df = create_segments_df(
             sections_df,
             text_column="body_text",
-            token_limit=1024,
-            words_per_token=0.78,
+            token_limit=256,
+            words_per_token=0.75,
         )
 
         # Save DataFrames

--- a/src/legiscope/segment.py
+++ b/src/legiscope/segment.py
@@ -15,8 +15,8 @@ import re
 import polars as pl
 
 # Text segmentation constants
-DEFAULT_TOKEN_LIMIT = 1024  # Maximum approximate tokens per segment
-DEFAULT_WORDS_PER_TOKEN = 0.78  # Approximate words per token ratio for embedding models
+DEFAULT_TOKEN_LIMIT = 256  # Maximum approximate tokens per segment
+DEFAULT_WORDS_PER_TOKEN = 0.75  # Approximate words per token ratio for embedding models
 
 
 def divide_into_sections(markdown_text: str) -> pl.DataFrame:
@@ -250,15 +250,16 @@ def segment_text(
     """
     Segment text into chunks suitable for processing and analysis.
 
-    Split text into segments that are approximately under the token limit using
-    word-based approximation. Prioritizes paragraph boundaries over sentence
+
+    Split text into segments that are approximately under the token limit (default: 256)
+    using word-based approximation. Prioritizes paragraph boundaries over sentence
     boundaries to maintain semantic coherence, with fallback to sentence and
     word-based splitting when needed.
 
     Args:
         text: Input text to be segmented
-        token_limit: Maximum approximate tokens per segment (default: 1024)
-        words_per_token: Approximate words per token ratio (default: 0.78)
+        token_limit: Maximum approximate tokens per segment (default: 256)
+        words_per_token: Approximate words per token ratio (default: 0.75)
                       This can be adjusted based on the specific model.
                       Note: Using word-based approximation for local embedding models
                       where exact tokenization may not be readily available.
@@ -499,8 +500,8 @@ def add_segments_to_sections(
     Args:
         df: DataFrame from divide_into_sections() with section information
         text_column: Name of column containing text to segment (default: "body_text")
-        token_limit: Maximum approximate tokens per segment (default: 1024)
-        words_per_token: Approximate words per token ratio (default: 0.78)
+        token_limit: Maximum approximate tokens per segment (default: 256)
+        words_per_token: Approximate words per token ratio (default: 0.75)
 
     Returns:
         DataFrame with additional columns:
@@ -582,8 +583,8 @@ def create_segments_df(
     Args:
         df: DataFrame from divide_into_sections() with section information
         text_column: Name of column containing text to segment (default: "body_text")
-        token_limit: Maximum approximate tokens per segment (default: 1024)
-        words_per_token: Approximate words per token ratio (default: 0.78)
+        token_limit: Maximum approximate tokens per segment (default: 256)
+        words_per_token: Approximate words per token ratio (default: 0.75)
 
     Returns:
         pl.DataFrame: Flattened DataFrame with one row per segment and columns:
@@ -638,8 +639,25 @@ def create_segments_df(
         if text is None or not text.strip():
             continue
 
+        # Adjust token limit based on the heading length to ensure combined size (heading + text)
+        # does not exceed embedding model context limit
+        heading_words = len(heading_text.split())
+        heading_tokens = int(heading_words / words_per_token)
+
+        # Ensure we always have a positive token limit for segmentation
+        # If heading is long, we still need to segment body text into reasonable chunks
+        # We allow exceeding the strict token_limit in this edge case to prevent crashing
+        min_tokens = 20
+        adjusted_token_limit = max(min_tokens, token_limit - heading_tokens)
+
         # Create segments for non-empty text
-        segments = segment_text(text, token_limit, words_per_token)
+        segments = segment_text(text, adjusted_token_limit, words_per_token)
+
+        # Validate that no segment exceeds the adjusted token limit
+        for segment in segments:
+            assert len(segment.split()) <= adjusted_token_limit * words_per_token, (
+                f"Segment exceeds token limit: {segment}"
+            )
 
         # Create a row for each segment
         for segment_position, segment_content in enumerate(segments):


### PR DESCRIPTION
## Description

With embeddinggemma, embedding was failing due to segmentation generating segments exceeding token limit. Adjusted logic to incorporate heading length into segment length to accommodate segment with long headings. Also decreased token limit to make smaller segments overall.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Dependency update or maintenance

## Related Issues

- None

## Changes Made

-Adjusts token limits for given sections to account for heading text tokens 
- Reduced default_token_limit to 256 Reduced default_words_per_token to 0.75

## Testing

<!-- Describe the testing you've done -->

- [x ] All existing tests pass (`make test`)
- [ ] Added new tests for new functionality
- [x ] Manual testing completed
- [x ] Code passes linting checks (`make lint`)

### Test Details

- passed unit tests
- manual testing with CA-LosAngeles

## Documentation

- [x ] Updated relevant documentation (README.md, AGENTS.md, docs/, etc.)
- [x ] Added docstrings for new functions/classes
- [ ] No documentation changes needed

## Checklist

- [x ] My code follows the project's code style
- [x ] I have performed a self-review of my code
- [x ] My commits follow the Conventional Commits standard
- [x ] I have commented my code where needed, particularly in complex areas
- [x ] My changes generate no new warnings

## Additional Context

- Documentation to be updated in future PR (7th in this series of PRs)