### PR TITLE
Add configurable CLI arguments for query and benchmark pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,40 @@ The pipeline can optionally run a batch of queries against the processed legal c
 ./scripts/pipeline.sh CA LosAngeles data/queries/test_queries.csv
 ```
 
+You can also run the query script directly for more control over processing options:
+
+```bash
+# Full configuration example (maximum control)
+source .venv/bin/activate
+python scripts/run_queries.py \
+    --queries-path "data/queries/test_queries.csv" \
+    --jurisdiction-id "CA-LosAngeles" \
+    --n-results 10 \
+    --use-hyde False \
+    --filter-relevance True \
+    --relevance-threshold 0.5 \
+    --validate-supporting-passages True \
+    --output "data/output/CA-LosAngeles/test_results.csv"
+
+# Minimal example (using defaults)
+source .venv/bin/activate
+python scripts/run_queries.py \
+    --queries-path "data/queries/test_queries.csv" \
+    --jurisdiction-id "CA-LosAngeles"
+```
+
+**Script Arguments (run_queries.py):**
+
+- `--queries-path`: Path to queries CSV file (required)
+- `--jurisdiction-id`: Target jurisdiction ID (e.g., "CA-LosAngeles") (required)
+- `--collection-name`: ChromaDB collection name (defaults to env var)
+- `--output`: Output CSV file path
+- `--n-results`: Number of results to retrieve per query (default: 10)
+- `--use-hyde`: Enable HYDE query rewriting (default: False)
+- `--filter-relevance`: Enable LLM-based relevance filtering (default: True)
+- `--relevance-threshold`: Confidence threshold for filtering (default: 0.5)
+- `--validate-supporting-passages`: Validate LLM citations against text (default: True)
+
 **Query File Format:**
 
 - CSV format with a "question" column

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -27,7 +27,7 @@ if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
 
 from legiscope.llm_config import Config
-from legiscope.utils import LLMConfig
+from legiscope.utils import LLMConfig, str2bool
 from legiscope.query import BatchQuerySettings, run_queries, load_queries
 from legiscope.eval import (
     Evaluator, 
@@ -80,6 +80,36 @@ def main():
         "--series-title",
         default="DPL_2025_Consolidated",
         help="MonQcle series title to use for ground truth"
+    )
+    parser.add_argument(
+        "--use-hyde",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="Enable HYDE query rewriting (default: False). Can be passed as '--use-hyde True/False'"
+    )
+    parser.add_argument(
+        "--filter-relevance",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="Enable LLM-based relevance filtering (default: False). Can be passed as '--filter-relevance True/False'"
+    )
+    parser.add_argument(
+        "--relevance-threshold",
+        type=float,
+        default=0.5,
+        help="Threshold for relevance filtering (0.0-1.0, default: 0.5)"
+    )
+    parser.add_argument(
+        "--validate-supporting-passages",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=True,
+        help="Enable validation of supporting passages against retrieved text (default: True). Can be passed as '--validate-supporting-passages True/False'"
     )
     parser.add_argument(
         "--debug",
@@ -188,8 +218,10 @@ def main():
     query_settings = BatchQuerySettings(
         llm=query_llm, 
         n_results=args.n_results, 
-        filter_relevance=True,
-        relevance_threshold=0.5
+        filter_relevance=args.filter_relevance,
+        relevance_threshold=args.relevance_threshold,
+        use_hyde=args.use_hyde,
+        validate_supporting_passages=args.validate_supporting_passages
     )
 
     # Evaluator Agent (Powerful model for judging)
@@ -296,5 +328,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
     main()

--- a/scripts/run_queries.py
+++ b/scripts/run_queries.py
@@ -24,7 +24,7 @@ if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
 
 from legiscope.llm_config import Config
-from legiscope.utils import LLMConfig
+from legiscope.utils import LLMConfig, str2bool
 from legiscope.query import BatchQuerySettings, run_queries, load_queries
 
 
@@ -42,6 +42,42 @@ def main():
     )
     parser.add_argument(
         "--output", default="data/output/query_results.csv", help="Output file path"
+    )
+    parser.add_argument(
+        "--n-results", 
+        type=int, 
+        default=10, 
+        help="Number of embedding segments to retrieve per query"
+    )
+    parser.add_argument(
+        "--use-hyde",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="Enable HYDE query rewriting (default: False). Can be passed as '--use-hyde True/False'"
+    )
+    parser.add_argument(
+        "--filter-relevance",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=True,
+        help="Enable LLM-based relevance filtering (default: True). Can be passed as '--filter-relevance True/False'"
+    )
+    parser.add_argument(
+        "--relevance-threshold",
+        type=float,
+        default=0.5,
+        help="Threshold for relevance filtering (0.0-1.0, default: 0.5)"
+    )
+    parser.add_argument(
+        "--validate-supporting-passages",
+        type=str2bool,
+        nargs='?',
+        const=True,
+        default=True,
+        help="Enable validation of supporting passages against retrieved text (default: True). Can be passed as '--validate-supporting-passages True/False'"
     )
 
     args = parser.parse_args()
@@ -62,7 +98,14 @@ def main():
         client=Config.get_powerful_client(), 
         model=Config.get_powerful_model()
     )
-    settings = BatchQuerySettings(llm=llm_config)
+    settings = BatchQuerySettings(
+        llm=llm_config,
+        n_results=args.n_results,
+        use_hyde=args.use_hyde,
+        filter_relevance=args.filter_relevance,
+        relevance_threshold=args.relevance_threshold,
+        validate_supporting_passages=args.validate_supporting_passages
+    )
 
     # Run queries with new API
     # run_queries now accepts list[QueryInput] directly

--- a/src/legiscope/query.py
+++ b/src/legiscope/query.py
@@ -77,6 +77,9 @@ class QuerySettings:
     filter_relevance: bool = False
     relevance_threshold: float = DEFAULT_RELEVANCE_THRESHOLD
     filter_llm: LLMConfig | None = None
+    
+    # Validation
+    validate_supporting_passages: bool = True
 
     def __post_init__(self):
         """Validate and set defaults after initialization."""
@@ -144,6 +147,7 @@ class BatchQuerySettings:
     # Query processing
     filter_relevance: bool = False
     relevance_threshold: float = DEFAULT_RELEVANCE_THRESHOLD
+    validate_supporting_passages: bool = True
 
     def __post_init__(self):
         """Validate and set defaults after initialization."""
@@ -520,7 +524,9 @@ def query_legal_documents(
         logger.debug("LLM call completed successfully")
 
         # Validate supporting passages against retrieved text
-        similarity_scores = _validate_supporting_passages(response, sections)
+        similarity_scores = []
+        if settings.validate_supporting_passages:
+            similarity_scores = _validate_supporting_passages(response, sections)
 
         return response, similarity_scores
 
@@ -842,6 +848,7 @@ def _process_single_query_with_error_handling(
             llm=llm,
             filter_relevance=settings.filter_relevance,
             relevance_threshold=settings.relevance_threshold,
+            validate_supporting_passages=settings.validate_supporting_passages
         )
 
         query_response, similarity_scores = query_legal_documents(

--- a/src/legiscope/utils.py
+++ b/src/legiscope/utils.py
@@ -2,6 +2,7 @@
 Utility functions for the legiscope package.
 """
 
+import argparse
 import os
 from dataclasses import dataclass
 from typing import Type, TypeVar
@@ -232,3 +233,14 @@ def create_jurisdiction_structure(state: str, municipality: str) -> str:
         raise OSError(
             f"Failed to create directory structure for {jurisdiction_name}: {str(e)}"
         ) from e
+
+def str2bool(v: str | bool) -> bool:
+    """Convert string to boolean for argparse."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')

--- a/tests/test_batch_settings.py
+++ b/tests/test_batch_settings.py
@@ -1,0 +1,37 @@
+"""
+Tests for new BatchQuerySettings parameters.
+"""
+
+import pytest
+from unittest.mock import Mock
+from legiscope.utils import LLMConfig
+from legiscope.query import BatchQuerySettings
+
+def test_batch_query_settings_defaults():
+    """Test default values for new parameters."""
+    mock_llm = Mock(spec=LLMConfig)
+    settings = BatchQuerySettings(llm=mock_llm)
+    
+    assert settings.n_results == 10
+    assert settings.use_hyde is False
+    assert settings.filter_relevance is False
+    assert settings.relevance_threshold == 0.5
+    assert settings.validate_supporting_passages is True
+
+def test_batch_query_settings_instantiation():
+    """Test instantiating with specific values."""
+    mock_llm = Mock(spec=LLMConfig)
+    settings = BatchQuerySettings(
+        llm=mock_llm,
+        n_results=20,
+        use_hyde=True,
+        filter_relevance=True,
+        relevance_threshold=0.8,
+        validate_supporting_passages=False
+    )
+    
+    assert settings.n_results == 20
+    assert settings.use_hyde is True
+    assert settings.filter_relevance is True
+    assert settings.relevance_threshold == 0.8
+    assert settings.validate_supporting_passages is False

--- a/tests/test_utils_str2bool.py
+++ b/tests/test_utils_str2bool.py
@@ -1,0 +1,56 @@
+"""Tests for legiscope.utils.str2bool."""
+
+import pytest
+import argparse
+from legiscope.utils import str2bool
+
+class TestStr2Bool:
+    """Test str2bool function."""
+
+    @pytest.mark.parametrize("value,expected", [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("t", True),
+        ("T", True),
+        ("yes", True),
+        ("YES", True),
+        ("y", True),
+        ("Y", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("f", False),
+        ("F", False),
+        ("no", False),
+        ("NO", False),
+        ("n", False),
+        ("N", False),
+        ("0", False),
+    ])
+    def test_valid_inputs(self, value, expected):
+        """Test valid boolean string representations."""
+        assert str2bool(value) == expected
+
+    @pytest.mark.parametrize("value", [
+        "maybe",
+        "2",
+        "foo",
+        "",
+        None,
+    ])
+    def test_invalid_inputs(self, value):
+        """Test invalid inputs raise ArgumentTypeError (if user provided) or TypeError."""
+        # argparse would catch this in real usage, but str2bool raises ArgumentTypeError
+        # or AttributeError if not string/bool.
+        if value is None:
+             # This depends on implementation if it expects strict string
+             # The implementation uses v.lower() so it will raise AttributeError for None
+             with pytest.raises(AttributeError):
+                 str2bool(value)
+        else:
+            with pytest.raises(argparse.ArgumentTypeError):
+                str2bool(value)


### PR DESCRIPTION
## Description

Added configurable CLI arguments to run_queries.py and benchmark_pipeline.py scripts

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Dependency update or maintenance

## Related Issues

- None

## Changes Made

- Added --use-hyde, --filter-relevance, --relevance-threshold, --validate-supporting-passages to benchmark_pipeline.py and run_queries.py
- Moved str2bool helper to utils.py
- Updated README with usage examples
- Added tests for new functionality

## Testing

- [x ] All existing tests pass (`make test`)
- [x ] Added new tests for new functionality
- [x ] Manual testing completed
- [x ] Code passes linting checks (`make lint`)


## Documentation

- [x ] Updated relevant documentation (README.md, AGENTS.md, docs/, etc.)
- [x ] Added docstrings for new functions/classes
- [ ] No documentation changes needed

## Checklist

- [x ] My code follows the project's code style
- [x ] I have performed a self-review of my code
- [x ] My commits follow the Conventional Commits standard
- [x ] I have commented my code where needed, particularly in complex areas
- [x ] My changes generate no new warnings

## Additional Context

- None