### PR TITLE
update HPC slurm scripts for bug fixes

### DIFF
--- a/coep/scripts/HPC_scripts/bootstrap_bigpurple.sh
+++ b/coep/scripts/HPC_scripts/bootstrap_bigpurple.sh
@@ -12,6 +12,8 @@ REPO_URL="https://github.com/jsqr/legiscope.git"
 BRANCH="main"
 STRICT=false
 NO_PULL=false
+GIT_USER_NAME_VALUE="${GIT_USER_NAME:-}"
+GIT_USER_EMAIL_VALUE="${GIT_USER_EMAIL:-}"
 
 usage() {
     cat <<'EOF'
@@ -24,7 +26,9 @@ Options:
   --project-root PATH   Override the repo location
   --docx-dir PATH       Override the flat DOCX staging directory
   --repo-url URL        Override the Git clone URL
-  --branch NAME         Branch to clone/pull (default: main)
+    --branch NAME         Branch to clone/pull (default: main)
+    --git-user-name NAME  Configure git config --global user.name
+    --git-user-email VAL  Configure git config --global user.email
   --strict              Exit non-zero if required inputs are missing
   --no-pull             Do not pull if the repo already exists
   -h, --help            Show this help
@@ -33,6 +37,10 @@ Optional environment variables for .env initialization:
   OPENROUTER_API_KEY_VALUE
   OPENAI_API_KEY_VALUE
   MISTRAL_API_KEY_VALUE
+
+Optional environment variables for Git identity:
+    GIT_USER_NAME
+    GIT_USER_EMAIL
 EOF
 }
 
@@ -52,6 +60,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --branch)
             BRANCH="$2"
+            shift 2
+            ;;
+        --git-user-name)
+            GIT_USER_NAME_VALUE="$2"
+            shift 2
+            ;;
+        --git-user-email)
+            GIT_USER_EMAIL_VALUE="$2"
             shift 2
             ;;
         --strict)
@@ -80,6 +96,35 @@ say() {
 
 warn() {
     printf 'WARNING: %s\n' "$1" >&2
+}
+
+configure_global_git_identity() {
+    local existing_name existing_email
+    existing_name="$(git config --global --get user.name 2>/dev/null || true)"
+    existing_email="$(git config --global --get user.email 2>/dev/null || true)"
+
+    if [[ -n "$existing_name" && -n "$existing_email" ]]; then
+        say ">>> Keeping existing global git identity"
+        say "Git user     : ${existing_name} <${existing_email}>"
+        return
+    fi
+
+    if [[ -n "$GIT_USER_NAME_VALUE" && -n "$GIT_USER_EMAIL_VALUE" ]]; then
+        say ">>> Configuring global git identity"
+        git config --global user.name "$GIT_USER_NAME_VALUE"
+        git config --global user.email "$GIT_USER_EMAIL_VALUE"
+        say "Git user     : ${GIT_USER_NAME_VALUE} <${GIT_USER_EMAIL_VALUE}>"
+        return
+    fi
+
+    if [[ -n "$GIT_USER_NAME_VALUE" || -n "$GIT_USER_EMAIL_VALUE" ]]; then
+        warn "Both git name and email are required to configure global git identity; skipping"
+        return
+    fi
+
+    warn "Global git identity is not set; configure it with:"
+    warn "  git config --global user.name \"Your Name\""
+    warn "  git config --global user.email \"you@example.com\""
 }
 
 require_cmd() {
@@ -118,6 +163,8 @@ else
 fi
 
 cd "$PROJECT_ROOT"
+
+configure_global_git_identity
 
 say ">>> Creating required directories"
 mkdir -p \

--- a/coep/scripts/HPC_scripts/slurm_benchmark.sh
+++ b/coep/scripts/HPC_scripts/slurm_benchmark.sh
@@ -27,9 +27,11 @@
 #   bash coep/scripts/HPC_scripts/rebuild_index.sh --clean
 #   sbatch coep/scripts/HPC_scripts/slurm_benchmark.sh
 #
-set -euo pipefail
+set -eo pipefail
 
 # ── Environment setup ────────────────────────────────────────────
+# BigPurple's /etc/bashrc references BASHRCSOURCED before defining it,
+# so these SLURM wrappers cannot enable nounset while sourcing ~/.bashrc.
 source ~/.bashrc
 export PYTHONNOUSERSITE=1
 # Skip 'module load anaconda3' — cuda/12.6 dependency has a read-only FS bug.
@@ -42,6 +44,26 @@ export TRANSFORMERS_CACHE=/gpfs/scratch/$USER/hf_cache
 
 cd /gpfs/data/cerdalab/LegalAI/legiscope
 
+configure_git_identity() {
+    local repo_dir="$1"
+    local git_name="${GIT_USER_NAME:-${GIT_AUTHOR_NAME:-}}"
+    local git_email="${GIT_USER_EMAIL:-${GIT_AUTHOR_EMAIL:-}}"
+
+    if [[ -z "$git_name" ]]; then
+        git_name="$(git -C "$repo_dir" config --get user.name 2>/dev/null || true)"
+    fi
+    if [[ -z "$git_email" ]]; then
+        git_email="$(git -C "$repo_dir" config --get user.email 2>/dev/null || true)"
+    fi
+
+    git_name="${git_name:-${USER:-legiscope-hpc}}"
+    git_email="${git_email:-${USER:-legiscope-hpc}@bigpurple.local}"
+
+    git -C "$repo_dir" config user.name "$git_name"
+    git -C "$repo_dir" config user.email "$git_email"
+    echo "Configured git identity for DVC: ${git_name} <${git_email}>"
+}
+
 # Load .env (API keys, etc.)
 if [[ ! -r .env ]]; then
     echo "ERROR: Required .env file is missing or not readable in $(pwd). Create it or fix its permissions before running the benchmark job." >&2
@@ -51,6 +73,8 @@ fi
 set -a
 source .env
 set +a
+
+configure_git_identity "$(pwd)"
 
 # ── Start vLLM server ───────────────────────────────────────────
 MODEL_ID="Qwen/Qwen3.5-4B"
@@ -78,7 +102,7 @@ trap "kill $VLLM_PID 2>/dev/null || true" EXIT
 READY_URL="http://${VLLM_HOST}:${VLLM_PORT}/health"
 
 echo "Waiting for vLLM server at ${READY_URL} (PID $VLLM_PID)..."
-TIMEOUT=900; ELAPSED=0
+TIMEOUT=1200; ELAPSED=0
 while ! curl -sf "$READY_URL" >/dev/null 2>&1; do
     if ! kill -0 $VLLM_PID 2>/dev/null; then echo "ERROR: vLLM died"; exit 1; fi
     if [ $ELAPSED -ge $TIMEOUT ]; then echo "ERROR: vLLM timeout"; exit 1; fi

--- a/coep/scripts/HPC_scripts/slurm_jurisdiction.sh
+++ b/coep/scripts/HPC_scripts/slurm_jurisdiction.sh
@@ -39,7 +39,7 @@
 #   sbatch --export=ALL,STATE=CA,LOCALITY=LosAngeles,DOCX_PATH=/gpfs/.../CA_LosAngeles.docx \
 #       coep/scripts/HPC_scripts/slurm_jurisdiction.sh
 #
-set -euo pipefail
+set -eo pipefail
 
 # ── Validate required inputs ─────────────────────────────────────
 for var in STATE LOCALITY DOCX_PATH; do
@@ -66,6 +66,8 @@ echo "Started : $(date)"
 echo "==========================================="
 
 # ── Environment setup ─────────────────────────────────────────────
+# BigPurple's /etc/bashrc references BASHRCSOURCED before defining it,
+# so these SLURM wrappers cannot enable nounset while sourcing ~/.bashrc.
 source ~/.bashrc
 export PYTHONNOUSERSITE=1
 # Skip 'module load anaconda3' — cuda/12.6 dependency has a read-only FS bug.
@@ -78,6 +80,26 @@ export HF_HOME=/gpfs/scratch/"$USER"/hf_cache
 export TRANSFORMERS_CACHE=/gpfs/scratch/"$USER"/hf_cache
 
 PROJECT_DIR="/gpfs/data/cerdalab/LegalAI/legiscope"
+
+configure_git_identity() {
+    local repo_dir="$1"
+    local git_name="${GIT_USER_NAME:-${GIT_AUTHOR_NAME:-}}"
+    local git_email="${GIT_USER_EMAIL:-${GIT_AUTHOR_EMAIL:-}}"
+
+    if [[ -z "$git_name" ]]; then
+        git_name="$(git -C "$PROJECT_DIR" config --get user.name 2>/dev/null || true)"
+    fi
+    if [[ -z "$git_email" ]]; then
+        git_email="$(git -C "$PROJECT_DIR" config --get user.email 2>/dev/null || true)"
+    fi
+
+    git_name="${git_name:-${USER:-legiscope-hpc}}"
+    git_email="${git_email:-${USER:-legiscope-hpc}@bigpurple.local}"
+
+    git -C "$repo_dir" config user.name "$git_name"
+    git -C "$repo_dir" config user.email "$git_email"
+    echo "Configured git identity for DVC: ${git_name} <${git_email}>"
+}
 
 # ── Step 1: Create isolated working copy ──────────────────────────
 # Each job gets its own copy of the repo in $TMPDIR to avoid
@@ -98,6 +120,7 @@ rsync -a \
 rsync -a "${PROJECT_DIR}/.git/" "${WORK_DIR}/.git/"
 
 cd "$WORK_DIR"
+export PYTHONPATH="$WORK_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
 
 # Load environment variables (.env has API keys including OPENROUTER_API_KEY)
 if [[ -f .env ]]; then
@@ -105,6 +128,8 @@ if [[ -f .env ]]; then
     source .env
     set +a
 fi
+
+configure_git_identity "$WORK_DIR"
 
 # ── Step 2: Edit params.yaml with jurisdiction metadata ───────────
 echo "Setting params.yaml: ${STATE} / ${LOCALITY} / ${CODE_SLUG}..."
@@ -160,7 +185,7 @@ VLLM_HOST=127.0.0.1
 READY_URL="http://${VLLM_HOST}:${VLLM_PORT}/health"
 
 echo "Waiting for vLLM server on ${READY_URL} (PID $VLLM_PID)..."
-TIMEOUT=900
+TIMEOUT=1200
 ELAPSED=0
 while ! curl -sf "$READY_URL" >/dev/null 2>&1; do
     if ! kill -0 "$VLLM_PID" 2>/dev/null; then

--- a/coep/scripts/HPC_scripts/sync_bigpurple_inputs.sh
+++ b/coep/scripts/HPC_scripts/sync_bigpurple_inputs.sh
@@ -107,6 +107,17 @@ require_cmd() {
 require_cmd ssh
 require_cmd rsync
 
+ssh_run() {
+    local remote="$1"
+    local command="$2"
+
+    if [[ -n "$SSH_JUMP" ]]; then
+        ssh -J "$SSH_JUMP" "$remote" "$command"
+    else
+        ssh "$remote" "$command"
+    fi
+}
+
 [[ -n "$NETID" ]] || die "--netid is required"
 [[ -n "$LOCAL_DOCX_DIR" ]] || die "--docx-dir is required"
 [[ -d "$LOCAL_DOCX_DIR" ]] || die "local DOCX directory not found: $LOCAL_DOCX_DIR"
@@ -122,10 +133,8 @@ if ! compgen -G "${LOCAL_DOCX_DIR}/*.docx" >/dev/null; then
 fi
 
 REMOTE="${NETID}@${HOST}"
-SSH_ARGS=()
 RSYNC_RSH="ssh"
 if [[ -n "$SSH_JUMP" ]]; then
-    SSH_ARGS=(-J "$SSH_JUMP")
     RSYNC_RSH="ssh -J ${SSH_JUMP}"
 fi
 
@@ -153,7 +162,7 @@ say ">>> Checking remote repo exists"
 if [[ "$DRY_RUN" == true ]]; then
     say "ssh ${REMOTE} \"${REMOTE_REPO_CHECK_CMD}\""
 else
-    if ! ssh "${SSH_ARGS[@]}" "$REMOTE" "$REMOTE_REPO_CHECK_CMD"; then
+    if ! ssh_run "$REMOTE" "$REMOTE_REPO_CHECK_CMD"; then
         die "remote repo not found at ${PROJECT_ROOT}; run bootstrap_bigpurple.sh on BigPurple first"
     fi
 fi
@@ -169,7 +178,7 @@ say ">>> Ensuring remote directories exist"
 if [[ "$DRY_RUN" == true ]]; then
     say "ssh ${REMOTE} \"${REMOTE_SETUP_CMD}\""
 else
-    ssh "${SSH_ARGS[@]}" "$REMOTE" "$REMOTE_SETUP_CMD"
+    ssh_run "$REMOTE" "$REMOTE_SETUP_CMD"
 fi
 
 say ">>> Syncing query CSV"
@@ -202,7 +211,7 @@ EOF
 if [[ "$DRY_RUN" == true ]]; then
     say "ssh ${REMOTE} \"${VERIFY_CMD}\""
 else
-    ssh "${SSH_ARGS[@]}" "$REMOTE" "$VERIFY_CMD"
+    ssh_run "$REMOTE" "$VERIFY_CMD"
 fi
 
 say ""

--- a/config.yaml
+++ b/config.yaml
@@ -22,5 +22,5 @@ database:
     model_suffix: true  # Append model name to collection (e.g., legal_code_mistral)
 
 logging:
-  level: "INFO"  # Use INFO by default; override to DEBUG for development
+  level: "DEBUG"  # Use INFO by default; override to DEBUG for development
   batch_log_interval: 1000


### PR DESCRIPTION
## Description

Adjusts HPC scripts to provide git identify configuration for dvc exp runs and adds bug fixes for slurm scripts.


## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Dependency update or maintenance

## Related Issues

- None

## Changes Made

- Fixed BigPurple SLURM startup by removing nounset before source ~/.bashrc, which avoided the BASHRCSOURCED failure in HPC jobs.
- Increased all HPC vLLM readiness timeouts to 1200 seconds for jurisdiction, benchmark, and smoke-test workflows.
- Fixed isolated jurisdiction jobs so the tmp repo copy can import legiscope by exporting PYTHONPATH to the copied src tree.
- Added Git identity handling for DVC experiment runs, including local repo identity setup inside SLURM jobs and optional global Git config setup in bootstrap.
- Hardened the local-to-BigPurple sync helper by replacing the empty-array SSH pattern with a wrapper function that works correctly on macOS bash.
- Switched config.yaml logging default from INFO to DEBUG.

## Testing

- [x ] All existing tests pass (`make test`)
- [ ] Added new tests for new functionality
- [ ] Manual testing completed
- [ ] Code passes linting checks (`make lint`)


## Documentation

- [ ] Updated relevant documentation (README.md, AGENTS.md, docs/, etc.)
- [ ] Added docstrings for new functions/classes
- [x ] No documentation changes needed

## Checklist

- [x ] My code follows the project's code style
- [x ] I have performed a self-review of my code
- [x ] My commits follow the Conventional Commits standard
- [x ] I have commented my code where needed, particularly in complex areas
- [x ] My changes generate no new warnings

